### PR TITLE
Prioritize artist over album artist for songs

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/model/Song.java
+++ b/app/src/main/java/com/dkanada/gramophone/model/Song.java
@@ -65,12 +65,12 @@ public class Song implements Parcelable {
         this.albumId = itemDto.getAlbumId();
         this.albumName = itemDto.getAlbum();
 
-        if (itemDto.getAlbumArtists().size() != 0) {
-            this.artistId = itemDto.getAlbumArtists().get(0).getId();
-            this.artistName = itemDto.getAlbumArtists().get(0).getName();
-        } else if (itemDto.getArtistItems().size() != 0) {
+        if (itemDto.getArtistItems().size() != 0) {
             this.artistId = itemDto.getArtistItems().get(0).getId();
             this.artistName = itemDto.getArtistItems().get(0).getName();
+        } else if (itemDto.getAlbumArtists().size() != 0) {
+            this.artistId = itemDto.getAlbumArtists().get(0).getId();
+            this.artistName = itemDto.getAlbumArtists().get(0).getName();
         }
 
         this.primary = itemDto.getAlbumPrimaryImageTag() != null ? albumId : null;


### PR DESCRIPTION
Currently, the album artist is used if set. IMHO this is the wrong
choice as it will lead to "Various Artists" or similar being shown
when playing tracks from a compilation.
Changed the code to use first look for the artist tag instead.