### PR TITLE
Use artist ID for primary image in constructors

### DIFF
--- a/app/src/main/java/com/dkanada/gramophone/model/Artist.java
+++ b/app/src/main/java/com/dkanada/gramophone/model/Artist.java
@@ -46,11 +46,13 @@ public class Artist implements Parcelable {
     public Artist(Album album) {
         this.id = album.artistId;
         this.name = album.artistName;
+        this.primary = this.id;
     }
 
     public Artist(Song song) {
         this.id = song.artistId;
         this.name = song.artistName;
+        this.primary = this.id;
     }
 
     public Artist() {


### PR DESCRIPTION
When using the constructor with an Album or Song, default the image to
the artist ID so the artist image always shows up when set.